### PR TITLE
Keep "level_start_box_nrs" in host memory

### DIFF
--- a/boxtree/tools.py
+++ b/boxtree/tools.py
@@ -270,7 +270,7 @@ class DeviceDataRecord(Record):
     instances on the host.
     """
 
-    def _transform_arrays(self, f):
+    def _transform_arrays(self, f, exclude_fields=frozenset()):
         result = {}
 
         def transform_val(val):
@@ -290,6 +290,9 @@ class DeviceDataRecord(Record):
                 return f(val)
 
         for field_name in self.__class__.fields:
+            if field_name in exclude_fields:
+                continue
+
             try:
                 attr = getattr(self, field_name)
             except AttributeError:
@@ -335,9 +338,12 @@ class DeviceDataRecord(Record):
 
         return self._transform_arrays(try_with_queue)
 
-    def to_device(self, queue):
+    def to_device(self, queue, exclude_fields=frozenset()):
         """ Return a copy of `self` in all :class:`numpy.ndarray` arrays are
         transferred to device memory as :class:`pyopencl.array.Array` objects.
+
+        :arg exclude_fields: a :class:`frozenset` containing fields excluding from
+            transferring to the device memory.
         """
 
         def _to_device(attr):
@@ -346,7 +352,7 @@ class DeviceDataRecord(Record):
             else:
                 return attr
 
-        return self._transform_arrays(_to_device)
+        return self._transform_arrays(_to_device, exclude_fields)
 
 # }}}
 

--- a/boxtree/tree.py
+++ b/boxtree/tree.py
@@ -394,7 +394,7 @@ class Tree(DeviceDataRecord):
         exclude_fields = set(exclude_fields)
         exclude_fields.add("level_start_box_nrs")
 
-        return super().to_device(queue, frozenset(exclude_fields))
+        return super(Tree, self).to_device(queue, frozenset(exclude_fields))
 
 # }}}
 

--- a/boxtree/tree.py
+++ b/boxtree/tree.py
@@ -389,6 +389,13 @@ class Tree(DeviceDataRecord):
 
     # }}}
 
+    def to_device(self, queue, exclude_fields=frozenset()):
+        # level_start_box_nrs should remain in host memory
+        exclude_fields = set(exclude_fields)
+        exclude_fields.add("level_start_box_nrs")
+
+        return super().to_device(queue, frozenset(exclude_fields))
+
 # }}}
 
 


### PR DESCRIPTION
Suppose `tree` is constructed by `TreeBuilder`. I would expect `tree` and `tree_dev` to be the same in the following code snippet
```
tree_host = tree.get(queue=queue)
tree_dev = tree_host.to_device(queue).with_queue(queue)
```
This code is helpful for me because when broadcasting the tree in the distributed implementation, the code first transfers the tree to the host memory on the root rank, calls mpi4py broadcast API and transfers the received tree back to device memory on worker ranks.

However,  `level_start_box_nrs` is expected to live on host memory in both `tree_host` and `tree_dev`, but currently `to_device` transfers it to device memory regardless. This PR intends to exclude `level_start_box_nrs` when transferring fields to device memory.