### PR TITLE
Move adaptive box bounding box from traversal to tree

### DIFF
--- a/boxtree/traversal.py
+++ b/boxtree/traversal.py
@@ -339,98 +339,6 @@ LEVEL_START_BOX_NR_EXTRACTOR_TEMPLATE = ElementwiseTemplate(
 
 # }}}
 
-# {{{ box extents
-
-BOX_EXTENTS_FINDER_TEMPLATE = ElementwiseTemplate(
-    arguments="""//CL:mako//
-    box_id_t aligned_nboxes,
-    box_id_t *box_child_ids,
-    coord_t *box_centers,
-    particle_id_t *box_particle_starts,
-    particle_id_t *box_particle_counts_nonchild
-
-    %for iaxis in range(dimensions):
-        , const coord_t *particle_${AXIS_NAMES[iaxis]}
-    %endfor
-    ,
-    const coord_t *particle_radii,
-    int enable_radii,
-
-    coord_t *box_particle_bounding_box_min,
-    coord_t *box_particle_bounding_box_max,
-    """,
-
-    operation=TRAVERSAL_PREAMBLE_MAKO_DEFS + r"""//CL:mako//
-        box_id_t ibox = i;
-
-        ${load_center("box_center", "ibox")}
-
-        <% axis_names = AXIS_NAMES[:dimensions] %>
-
-        // incorporate own particles
-        %for iaxis, ax in enumerate(axis_names):
-            coord_t min_particle_${ax} = box_center.s${iaxis};
-            coord_t max_particle_${ax} = box_center.s${iaxis};
-        %endfor
-
-        particle_id_t start = box_particle_starts[ibox];
-        particle_id_t stop = start + box_particle_counts_nonchild[ibox];
-
-        for (particle_id_t iparticle = start; iparticle < stop; ++iparticle)
-        {
-            coord_t particle_rad = 0;
-            %if sources_have_extent or targets_have_extent:
-                // If only one has extent, then the radius array for the other
-                // may well be a null pointer.
-                if (enable_radii)
-                    particle_rad = particle_radii[iparticle];
-            %endif
-
-            %for iaxis, ax in enumerate(axis_names):
-                coord_t particle_coord_${ax} = particle_${ax}[iparticle];
-
-                min_particle_${ax} = min(
-                    min_particle_${ax},
-                    particle_coord_${ax} - particle_rad);
-                max_particle_${ax} = max(
-                    max_particle_${ax},
-                    particle_coord_${ax} + particle_rad);
-            %endfor
-        }
-
-        // incorporate child boxes
-        for (int morton_nr = 0; morton_nr < ${2**dimensions}; ++morton_nr)
-        {
-            box_id_t child_id = box_child_ids[
-                    morton_nr * aligned_nboxes + ibox];
-
-            if (child_id == 0)
-                continue;
-
-            %for iaxis, ax in enumerate(axis_names):
-                min_particle_${ax} = min(
-                    min_particle_${ax},
-                    box_particle_bounding_box_min[
-                        ${iaxis} * aligned_nboxes + child_id]);
-                max_particle_${ax} = max(
-                    max_particle_${ax},
-                    box_particle_bounding_box_max[
-                        ${iaxis} * aligned_nboxes + child_id]);
-            %endfor
-        }
-
-        // write result
-        %for iaxis, ax in enumerate(axis_names):
-            box_particle_bounding_box_min[
-                ${iaxis} * aligned_nboxes + ibox] = min_particle_${ax};
-            box_particle_bounding_box_max[
-                ${iaxis} * aligned_nboxes + ibox] = max_particle_${ax};
-        %endfor
-    """,
-    name="find_box_extents")
-
-# }}}
-
 # {{{ same-level non-well-separated boxes (generalization of "colleagues")
 
 SAME_LEVEL_NON_WELL_SEP_BOXES_TEMPLATE = r"""//CL//
@@ -1462,42 +1370,6 @@ class FMMTraversalInfo(DeviceDataRecord):
         each level starts and ends.
 
     .. ------------------------------------------------------------------------
-    .. rubric:: Particle-adaptive box extents
-    .. ------------------------------------------------------------------------
-
-    The attributes in this section are only available if the respective
-    particle type (source/target) has extents. These capture the maximum extent
-    of particles (including the particle's extents) inside of the box.  If the
-    box is empty, both *min* and *max* will reflect the box center.  The
-    purpose of this information is to reduce the cost of some interactions
-    through knowledge that some boxes are partially empty.
-    (See the *from_sep_smaller_crit* argument to the constructor of
-    :class:`FMMTraversalBuilder` for an example.)
-
-    .. note::
-
-        To obtain the overall, non-adaptive box extent, use
-        :attr:`boxtree.Tree.box_centers` along with :attr:`boxtree.Tree.box_levels`.
-
-    If they are not available, the corresponding attributes will be *None*.
-
-    .. attribute:: box_source_bounding_box_min
-
-        ``coordt_t [dimensions, aligned_nboxes]``
-
-    .. attribute:: box_source_bounding_box_max
-
-        ``coordt_t [dimensions, aligned_nboxes]``
-
-    .. attribute:: box_target_bounding_box_min
-
-        ``coordt_t [dimensions, aligned_nboxes]``
-
-    .. attribute:: box_target_bounding_box_max
-
-        ``coordt_t [dimensions, aligned_nboxes]``
-
-    .. ------------------------------------------------------------------------
     .. rubric:: Same-level non-well-separated boxes
     .. ------------------------------------------------------------------------
 
@@ -1856,23 +1728,6 @@ class FMMTraversalBuilder:
                         debug=debug,
                         name_prefix="sources_parents_and_targets")
 
-        result["box_extents_finder"] = \
-                BOX_EXTENTS_FINDER_TEMPLATE.build(self.context,
-                    type_aliases=(
-                        ("box_id_t", box_id_dtype),
-                        ("coord_t", coord_dtype),
-                        ("coord_vec_t", cl.cltypes.vec_types[
-                            coord_dtype, dimensions]),
-                        ("particle_id_t", particle_id_dtype),
-                        ),
-                    var_values=(
-                        ("dimensions", dimensions),
-                        ("AXIS_NAMES", AXIS_NAMES),
-                        ("sources_have_extent", sources_have_extent),
-                        ("targets_have_extent", targets_have_extent),
-                        ),
-                    )
-
         result["level_start_box_nrs_extractor"] = \
                 LEVEL_START_BOX_NR_EXTRACTOR_TEMPLATE.build(self.context,
                     type_aliases=(
@@ -2083,90 +1938,6 @@ class FMMTraversalBuilder:
 
         # }}}
 
-        # {{{ box extents
-
-        fin_debug("finding box extents")
-
-        box_source_bounding_box_min = cl.array.empty(
-                queue, (tree.dimensions, tree.aligned_nboxes),
-                dtype=tree.coord_dtype)
-        box_source_bounding_box_max = cl.array.empty(
-                queue, (tree.dimensions, tree.aligned_nboxes),
-                dtype=tree.coord_dtype)
-
-        if tree.sources_are_targets:
-            box_target_bounding_box_min = box_source_bounding_box_min
-            box_target_bounding_box_max = box_source_bounding_box_max
-        else:
-            box_target_bounding_box_min = cl.array.empty(
-                    queue, (tree.dimensions, tree.aligned_nboxes),
-                    dtype=tree.coord_dtype)
-            box_target_bounding_box_max = cl.array.empty(
-                    queue, (tree.dimensions, tree.aligned_nboxes),
-                    dtype=tree.coord_dtype)
-
-        bogus_radii_array = cl.array.empty(queue, 1, dtype=tree.coord_dtype)
-
-        # nlevels-1 is the highest valid level index
-        for level in range(tree.nlevels-1, -1, -1):
-            start, stop = tree.level_start_box_nrs[level:level+2]
-
-            for (skip, enable_radii, bbox_min, bbox_max,
-                    pstarts, pcounts, radii_tree_attr, particles) in [
-                    (
-                        # never skip
-                        False,
-
-                        tree.sources_have_extent,
-                        box_source_bounding_box_min,
-                        box_source_bounding_box_max,
-                        tree.box_source_starts,
-                        tree.box_source_counts_nonchild,
-                        "source_radii",
-                        tree.sources),
-                    (
-                        # skip the 'target' round if sources and targets
-                        # are the same.
-                        tree.sources_are_targets,
-
-                        tree.targets_have_extent,
-                        box_target_bounding_box_min,
-                        box_target_bounding_box_max,
-                        tree.box_target_starts,
-                        tree.box_target_counts_nonchild,
-                        "target_radii",
-                        tree.targets),
-                    ]:
-
-                if skip:
-                    continue
-
-                args = (
-                        (
-                            tree.aligned_nboxes,
-                            tree.box_child_ids,
-                            tree.box_centers,
-                            pstarts, pcounts,)
-                        + tuple(particles)
-                        + (
-                            getattr(tree, radii_tree_attr, bogus_radii_array),
-                            enable_radii,
-
-                            bbox_min,
-                            bbox_max))
-
-                evt = knl_info.box_extents_finder(
-                        *args,
-
-                        range=slice(start, stop),
-                        queue=queue, wait_for=wait_for)
-
-            wait_for = [evt]
-
-        del bogus_radii_array
-
-        # }}}
-
         # {{{ same-level non-well-separated boxes
 
         # If well_sep_is_n_away is 1, this agrees with the definition of
@@ -2229,8 +2000,8 @@ class FMMTraversalBuilder:
                 tree.stick_out_factor, target_boxes,
                 same_level_non_well_sep_boxes.starts,
                 same_level_non_well_sep_boxes.lists,
-                box_target_bounding_box_min.data,
-                box_target_bounding_box_max.data,
+                tree.box_target_bounding_box_min.data,
+                tree.box_target_bounding_box_max.data,
                 tree.box_source_counts_cumul,
                 _from_sep_smaller_min_nsources_cumul,
                 )
@@ -2356,11 +2127,6 @@ class FMMTraversalBuilder:
                 target_or_target_parent_boxes=target_or_target_parent_boxes,
                 level_start_target_or_target_parent_box_nrs=(
                     level_start_target_or_target_parent_box_nrs),
-
-                box_source_bounding_box_min=box_source_bounding_box_min,
-                box_source_bounding_box_max=box_source_bounding_box_max,
-                box_target_bounding_box_min=box_target_bounding_box_min,
-                box_target_bounding_box_max=box_target_bounding_box_max,
 
                 same_level_non_well_sep_boxes_starts=(
                     same_level_non_well_sep_boxes.starts),

--- a/boxtree/tree.py
+++ b/boxtree/tree.py
@@ -362,6 +362,42 @@ class Tree(DeviceDataRecord):
 
         A bitwise combination of :class:`box_flags_enum` constants.
 
+    .. ------------------------------------------------------------------------
+    .. rubric:: Particle-adaptive box extents
+    .. ------------------------------------------------------------------------
+
+    The attributes in this section are only available if the respective
+    particle type (source/target) has extents. These capture the maximum extent
+    of particles (including the particle's extents) inside of the box.  If the
+    box is empty, both *min* and *max* will reflect the box center.  The
+    purpose of this information is to reduce the cost of some interactions
+    through knowledge that some boxes are partially empty.
+    (See the *from_sep_smaller_crit* argument to the constructor of
+    :class:`boxtree.traversal.FMMTraversalBuilder` for an example.)
+
+    .. note::
+
+        To obtain the overall, non-adaptive box extent, use
+        :attr:`boxtree.Tree.box_centers` along with :attr:`boxtree.Tree.box_levels`.
+
+    If they are not available, the corresponding attributes will be *None*.
+
+    .. attribute:: box_source_bounding_box_min
+
+        ``coordt_t [dimensions, aligned_nboxes]``
+
+    .. attribute:: box_source_bounding_box_max
+
+        ``coordt_t [dimensions, aligned_nboxes]``
+
+    .. attribute:: box_target_bounding_box_min
+
+        ``coordt_t [dimensions, aligned_nboxes]``
+
+    .. attribute:: box_target_bounding_box_max
+
+        ``coordt_t [dimensions, aligned_nboxes]``
+
     .. rubric:: Methods
 
     .. automethod:: get

--- a/boxtree/tree.py
+++ b/boxtree/tree.py
@@ -366,12 +366,10 @@ class Tree(DeviceDataRecord):
     .. rubric:: Particle-adaptive box extents
     .. ------------------------------------------------------------------------
 
-    The attributes in this section are only available if the respective
-    particle type (source/target) has extents. These capture the maximum extent
-    of particles (including the particle's extents) inside of the box.  If the
-    box is empty, both *min* and *max* will reflect the box center.  The
-    purpose of this information is to reduce the cost of some interactions
-    through knowledge that some boxes are partially empty.
+    These attributes capture the maximum extent of particles (including the
+    particle's extents) inside of the box.  If the box is empty, both *min* and *max*
+    will reflect the box center.  The purpose of this information is to reduce the
+    cost of some interactions through knowledge that some boxes are partially empty.
     (See the *from_sep_smaller_crit* argument to the constructor of
     :class:`boxtree.traversal.FMMTraversalBuilder` for an example.)
 

--- a/boxtree/tree_build.py
+++ b/boxtree/tree_build.py
@@ -1629,6 +1629,91 @@ class TreeBuilder:
         # }}}
 
         del box_has_children
+        wait_for = [evt]
+
+        # {{{ compute box bounding box
+
+        fin_debug("finding box extents")
+
+        box_source_bounding_box_min = cl.array.empty(
+                queue, (dimensions, aligned_nboxes),
+                dtype=coord_dtype)
+        box_source_bounding_box_max = cl.array.empty(
+                queue, (dimensions, aligned_nboxes),
+                dtype=coord_dtype)
+
+        if sources_are_targets:
+            box_target_bounding_box_min = box_source_bounding_box_min
+            box_target_bounding_box_max = box_source_bounding_box_max
+        else:
+            box_target_bounding_box_min = cl.array.empty(
+                    queue, (dimensions, aligned_nboxes),
+                    dtype=coord_dtype)
+            box_target_bounding_box_max = cl.array.empty(
+                    queue, (dimensions, aligned_nboxes),
+                    dtype=coord_dtype)
+
+        bogus_radii_array = cl.array.empty(queue, 1, dtype=coord_dtype)
+
+        # nlevels-1 is the highest valid level index
+        for level in range(nlevels-1, -1, -1):
+            start, stop = level_start_box_nrs[level:level+2]
+
+            for (skip, enable_radii, box_bounding_box_min, box_bounding_box_max,
+                    pstarts, pcounts, particle_radii, particles) in [
+                    (
+                        # never skip
+                        False,
+
+                        sources_have_extent,
+                        box_source_bounding_box_min,
+                        box_source_bounding_box_max,
+                        box_source_starts,
+                        box_source_counts_nonchild,
+                        source_radii if sources_have_extent else bogus_radii_array,
+                        sources),
+                    (
+                        # skip the 'target' round if sources and targets
+                        # are the same.
+                        sources_are_targets,
+
+                        targets_have_extent,
+                        box_target_bounding_box_min,
+                        box_target_bounding_box_max,
+                        box_target_starts,
+                        box_target_counts_nonchild,
+                        target_radii if targets_have_extent else bogus_radii_array,
+                        targets),
+                    ]:
+
+                if skip:
+                    continue
+
+                args = (
+                        (
+                            aligned_nboxes,
+                            box_child_ids,
+                            box_centers,
+                            pstarts, pcounts,)
+                        + tuple(particles)
+                        + (
+                            particle_radii,
+                            enable_radii,
+
+                            box_bounding_box_min,
+                            box_bounding_box_max))
+
+                evt = knl_info.box_extents_finder_kernel(
+                        *args,
+
+                        range=slice(start, stop),
+                        queue=queue, wait_for=wait_for)
+
+            wait_for = [evt]
+
+        del bogus_radii_array
+
+        # }}}
 
         # {{{ build output
 
@@ -1684,6 +1769,11 @@ class TreeBuilder:
 
                 user_source_ids=user_source_ids,
                 sorted_target_ids=sorted_target_ids,
+
+                box_source_bounding_box_min=box_source_bounding_box_min,
+                box_source_bounding_box_max=box_source_bounding_box_max,
+                box_target_bounding_box_min=box_target_bounding_box_min,
+                box_target_bounding_box_max=box_target_bounding_box_max,
 
                 _is_pruned=prune_empty_leaves,
 

--- a/test/test_traversal.py
+++ b/test/test_traversal.py
@@ -259,30 +259,6 @@ def test_tree_connectivity(ctx_factory, dims, sources_are_targets):
 
     # }}}
 
-    # {{{ box extents make sense
-
-    for ibox in range(tree.nboxes):
-        ext_low, ext_high = tree.get_box_extent(ibox)
-        center = tree.box_centers[:, ibox]
-
-        for _, bbox_min, bbox_max in [
-                (
-                    "source",
-                    trav.box_source_bounding_box_min[:, ibox],
-                    trav.box_source_bounding_box_max[:, ibox]),
-                (
-                    "target",
-                    trav.box_target_bounding_box_min[:, ibox],
-                    trav.box_target_bounding_box_max[:, ibox]),
-                ]:
-            assert (ext_low <= bbox_min).all()
-            assert (bbox_min <= center).all()
-
-            assert (bbox_max <= ext_high).all()
-            assert (center <= bbox_max).all()
-
-    # }}}
-
 # }}}
 
 

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -147,6 +147,24 @@ def run_build_test(builder, queue, dims, dtype, nparticles, do_plot,
         assert (extent_high <= tree.bounding_box[1] + scaled_tol).all(), (
                 ibox, extent_high, tree.bounding_box[1])
 
+        center = tree.box_centers[:, ibox]
+
+        for _, bbox_min, bbox_max in [
+                (
+                    "source",
+                    tree.box_source_bounding_box_min[:, ibox],
+                    tree.box_source_bounding_box_max[:, ibox]),
+                (
+                    "target",
+                    tree.box_target_bounding_box_min[:, ibox],
+                    tree.box_target_bounding_box_max[:, ibox]),
+                ]:
+            assert (extent_low - scaled_tol <= bbox_min).all()
+            assert (bbox_min - scaled_tol <= center).all()
+
+            assert (bbox_max - scaled_tol <= extent_high).all()
+            assert (center - scaled_tol <= bbox_max).all()
+
         start = tree.box_source_starts[ibox]
 
         box_children = tree.box_child_ids[:, ibox]


### PR DESCRIPTION
This PR intends to move the following fields from the traversal object to the tree object.
```
box_source_bounding_box_min
box_source_bounding_box_max
box_target_bounding_box_min
box_target_bounding_box_max
```
The motivation for this PR is to simplify the distributed implementation. See https://github.com/inducer/boxtree/pull/49#discussion_r815990217.