### PR TITLE
Rename `nterms` to `order` for the fmmlib wrangler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,5 +89,9 @@ jobs:
                 . ./ci-support-v0
 
                 export PYTEST_ADDOPTS="-k 'not slowtest'"
+                
+                if [[ "$DOWNSTREAM_PROJECT" == "pytential" && "$GITHUB_HEAD_REF" == "rename-nterms" ]]; then
+                   DOWNSTREAM_PROJECT=https://github.com/gaohao95/pytential.git@rename-nterms
+                fi
                 test_downstream "$DOWNSTREAM_PROJECT"
 # vim: sw=4

--- a/boxtree/distributed/__init__.py
+++ b/boxtree/distributed/__init__.py
@@ -189,13 +189,11 @@ class DistributedFMMRunner:
                 calibration_params = \
                     FMMCostModel.get_unit_calibration_params()
 
-            # We need to construct a wrangler in order to access `level_nterms`
+            # We need to construct a wrangler in order to access `level_orders`
             global_wrangler = wrangler_factory(global_trav, global_trav)
 
             cost_per_box = cost_model.cost_per_box(
-                # Currently only pyfmmlib has `level_nterms` field.
-                # See https://gitlab.tiker.net/inducer/boxtree/-/issues/25.
-                queue, global_trav_dev, global_wrangler.level_nterms,
+                queue, global_trav_dev, global_wrangler.level_orders,
                 calibration_params
             ).get()
 

--- a/boxtree/distributed/calculation.py
+++ b/boxtree/distributed/calculation.py
@@ -392,7 +392,7 @@ class DistributedFMMLibExpansionWrangler(
         DistributedExpansionWrangler, FMMLibExpansionWrangler):
     def __init__(
             self, context, comm, tree_indep, local_traversal, global_traversal,
-            fmm_level_to_nterms=None,
+            fmm_level_to_order=None,
             communicate_mpoles_via_allreduce=False,
             **kwargs):
         DistributedExpansionWrangler.__init__(
@@ -400,7 +400,7 @@ class DistributedFMMLibExpansionWrangler(
             communicate_mpoles_via_allreduce=communicate_mpoles_via_allreduce)
         FMMLibExpansionWrangler.__init__(
             self, tree_indep, local_traversal,
-            fmm_level_to_nterms=fmm_level_to_nterms, **kwargs)
+            fmm_level_to_order=fmm_level_to_order, **kwargs)
 
     #TODO: use log_process like FMMLibExpansionWrangler?
     def reorder_sources(self, source_array):

--- a/examples/cost_model.py
+++ b/examples/cost_model.py
@@ -39,10 +39,10 @@ def demo_cost_model():
 
     traversals = []
     traversals_dev = []
-    level_to_orders = []
+    level_orders_list = []
     timing_results = []
 
-    def fmm_level_to_nterms(tree, ilevel):
+    def fmm_level_to_order(tree, ilevel):
         return 10
 
     for nsources, ntargets in zip(nsources_list, ntargets_list):
@@ -82,8 +82,8 @@ def demo_cost_model():
         tree_indep = FMMLibTreeIndependentDataForWrangler(
                 trav.tree.dimensions, Kernel.LAPLACE)
         wrangler = FMMLibExpansionWrangler(tree_indep, trav,
-                fmm_level_to_nterms=fmm_level_to_nterms)
-        level_to_orders.append(wrangler.level_nterms)
+                fmm_level_to_order=fmm_level_to_order)
+        level_orders_list.append(wrangler.level_orders)
 
         timing_data = {}
         from boxtree.fmm import drive_fmm
@@ -103,7 +103,7 @@ def demo_cost_model():
         traversal = traversals_dev[icase]
         model_results.append(
             cost_model.cost_per_stage(
-                queue, traversal, level_to_orders[icase],
+                queue, traversal, level_orders_list[icase],
                 FMMCostModel.get_unit_calibration_params(),
             )
         )
@@ -114,7 +114,7 @@ def demo_cost_model():
     )
 
     predicted_time = cost_model.cost_per_stage(
-        queue, traversals_dev[-1], level_to_orders[-1], params,
+        queue, traversals_dev[-1], level_orders_list[-1], params,
     )
     queue.finish()
 

--- a/test/test_cost_model.py
+++ b/test/test_cost_model.py
@@ -388,7 +388,7 @@ def test_estimate_calibration_params(actx_factory):
     level_to_orders = []
     timing_results = []
 
-    def fmm_level_to_nterms(tree, ilevel):
+    def fmm_level_to_order(tree, ilevel):
         return 10
 
     for nsources, ntargets in zip(nsources_list, ntargets_list):
@@ -425,8 +425,8 @@ def test_estimate_calibration_params(actx_factory):
         tree_indep = FMMLibTreeIndependentDataForWrangler(
                 trav.tree.dimensions, Kernel.LAPLACE)
         wrangler = FMMLibExpansionWrangler(tree_indep, trav,
-                fmm_level_to_nterms=fmm_level_to_nterms)
-        level_to_orders.append(wrangler.level_nterms)
+                fmm_level_to_order=fmm_level_to_order)
+        level_to_orders.append(wrangler.level_orders)
 
         timing_data = {}
         from boxtree.fmm import drive_fmm

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -77,7 +77,7 @@ def _test_against_shared(
     # Configure array context
     actx = _acf()
 
-    def fmm_level_to_nterms(tree, level):
+    def fmm_level_to_order(tree, level):
         return max(level, 3)
 
     from boxtree.traversal import FMMTraversalBuilder
@@ -110,7 +110,7 @@ def _test_against_shared(
         # Get pyfmmlib expansion wrangler
         wrangler = FMMLibExpansionWrangler(
                 tree_indep, global_traversal_host,
-                fmm_level_to_nterms=fmm_level_to_nterms)
+                fmm_level_to_order=fmm_level_to_order)
 
         # Compute FMM using shared memory parallelism
         from boxtree.fmm import drive_fmm
@@ -124,7 +124,7 @@ def _test_against_shared(
 
         return DistributedFMMLibExpansionWrangler(
             actx.context, comm, tree_indep, local_traversal, global_traversal,
-            fmm_level_to_nterms=fmm_level_to_nterms,
+            fmm_level_to_order=fmm_level_to_order,
             communicate_mpoles_via_allreduce=communicate_mpoles_via_allreduce)
 
     from boxtree.distributed import DistributedFMMRunner
@@ -192,7 +192,7 @@ def _test_constantone(dims, nsources, ntargets, dtype):
                 communicate_mpoles_via_allreduce=True)
             ConstantOneExpansionWranglerBase.__init__(
                 self, tree_indep, local_traversal)
-            self.level_nterms = np.ones(local_traversal.tree.nlevels, dtype=np.int32)
+            self.level_orders = np.ones(local_traversal.tree.nlevels, dtype=np.int32)
 
         def reorder_sources(self, source_array):
             if self.comm.Get_rank() == 0:

--- a/test/test_fmm.py
+++ b/test/test_fmm.py
@@ -423,12 +423,12 @@ def test_pyfmmlib_fmm(actx_factory, dims, use_dipoles, helmholtz_k):
         dipole_vec = None
 
     if dims == 2 and helmholtz_k == 0:
-        base_nterms = 20
+        base_order = 20
     else:
-        base_nterms = 10
+        base_order = 10
 
-    def fmm_level_to_nterms(tree, lev):
-        result = base_nterms
+    def fmm_level_to_order(tree, lev):
+        result = base_order
 
         if lev < 3 and helmholtz_k:
             # exercise order-varies-by-level capability
@@ -447,7 +447,7 @@ def test_pyfmmlib_fmm(actx_factory, dims, use_dipoles, helmholtz_k):
     wrangler = FMMLibExpansionWrangler(
             tree_indep, trav,
             helmholtz_k=helmholtz_k,
-            fmm_level_to_nterms=fmm_level_to_nterms,
+            fmm_level_to_order=fmm_level_to_order,
             dipole_vec=dipole_vec)
 
     from boxtree.fmm import drive_fmm
@@ -563,7 +563,7 @@ def test_pyfmmlib_numerical_stability(actx_factory, dims, helmholtz_k, order):
             Kernel, FMMLibTreeIndependentDataForWrangler,
             FMMLibExpansionWrangler, FMMLibRotationData)
 
-    def fmm_level_to_nterms(tree, lev):
+    def fmm_level_to_order(tree, lev):
         return order
 
     tree_indep = FMMLibTreeIndependentDataForWrangler(
@@ -572,7 +572,7 @@ def test_pyfmmlib_numerical_stability(actx_factory, dims, helmholtz_k, order):
     wrangler = FMMLibExpansionWrangler(
             tree_indep, trav,
             helmholtz_k=helmholtz_k,
-            fmm_level_to_nterms=fmm_level_to_nterms,
+            fmm_level_to_order=fmm_level_to_order,
             rotation_data=FMMLibRotationData(actx.queue, trav))
 
     from boxtree.fmm import drive_fmm
@@ -743,10 +743,10 @@ def test_fmm_with_optimized_3d_m2l(actx_factory, nsrcntgts, helmholtz_k,
     rng = np.random.default_rng(20)
     weights = rng.uniform(0.0, 1.0, (nsources,))
 
-    base_nterms = 10
+    base_order = 10
 
-    def fmm_level_to_nterms(tree, lev):
-        result = base_nterms
+    def fmm_level_to_order(tree, lev):
+        result = base_order
 
         if lev < 3 and helmholtz_k:
             # exercise order-varies-by-level capability
@@ -764,12 +764,12 @@ def test_fmm_with_optimized_3d_m2l(actx_factory, nsrcntgts, helmholtz_k,
     baseline_wrangler = FMMLibExpansionWrangler(
             tree_indep, trav,
             helmholtz_k=helmholtz_k,
-            fmm_level_to_nterms=fmm_level_to_nterms)
+            fmm_level_to_order=fmm_level_to_order)
 
     optimized_wrangler = FMMLibExpansionWrangler(
             tree_indep, trav,
             helmholtz_k=helmholtz_k,
-            fmm_level_to_nterms=fmm_level_to_nterms,
+            fmm_level_to_order=fmm_level_to_order,
             rotation_data=FMMLibRotationData(actx.queue, trav))
 
     from boxtree.fmm import drive_fmm


### PR DESCRIPTION
As discussed in https://gitlab.tiker.net/inducer/boxtree/-/issues/25, `nterms` in fmmlib is a misnomer. This PR intends to change that to `order` to make it consistent with Sumpy's wrangler.

- [x] Mutually dependent on https://github.com/inducer/pytential/pull/153