### PR TITLE
Extend the distributed implementation to support Sumpy

### DIFF
--- a/boxtree/distributed/partition.py
+++ b/boxtree/distributed/partition.py
@@ -329,6 +329,10 @@ def get_box_masks(queue, traversal, responsible_boxes_list):
     """
     code = GetBoxMasksCodeContainer(queue.context, traversal.tree.box_id_dtype)
 
+    # FIXME: It is wasteful to copy the whole traversal object into device memory
+    # here because
+    # 1) Not all fields are needed.
+    # 2) For sumpy wrangler, a device traversal object is already available.
     traversal = traversal.to_device(queue)
 
     responsible_boxes_mask = np.zeros((traversal.tree.nboxes,), dtype=np.int8)

--- a/boxtree/fmm.py
+++ b/boxtree/fmm.py
@@ -341,7 +341,8 @@ def drive_fmm(wrangler: ExpansionWranglerInterface, src_weight_vecs,
         :class:`boxtree.distributed.calculation.DistributedExpansionWrangler`.
     :arg src_weight_vecs: A sequence of source 'density/weights/charges'.
         Passed unmodified to *expansion_wrangler*. For distributed
-        implementation, this argument is only significant on the root rank.
+        implementation, this argument is only significant on the root rank, but
+        worker ranks still need to supply a dummy vector.
     :arg timing_data: Either *None*, or a :class:`dict` that is populated with
         timing information for the stages of the algorithm (in the form of
         :class:`~boxtree.timing.TimingResult`), if such information is available.


### PR DESCRIPTION
- Make the `DistributedFMMRunner` accept trees both in the host and the device memory.
- Use structure of arrays instead of multi-dimentional arrays for particles passed into kernels.

After merge:
- Look at https://github.com/inducer/sumpy/pull/137