### PR TITLE
Do not use dtype[Any] to preserve py<39 compatibility (closes gh-63)

### DIFF
--- a/boxtree/tools.py
+++ b/boxtree/tools.py
@@ -916,7 +916,7 @@ class ImmutableHostDeviceArray:
 # {{{ coord_vec tools
 
 def get_coord_vec_dtype(
-        coord_dtype: np.dtype[Any], dimensions: int) -> np.dtype[Any]:
+        coord_dtype: np.dtype, dimensions: int) -> np.dtype:
     if dimensions == 1:
         return coord_dtype
     else:


### PR DESCRIPTION
FYI @isuruf 

I'm not sure the `[Any]` is helpful in any way, particular since we're miles away from typechecking any of this code.