### PR TITLE
Fix deprecated scalar array to int conversion

### DIFF
--- a/boxtree/tree.py
+++ b/boxtree/tree.py
@@ -1137,7 +1137,7 @@ class ParticleListFilter:
                 nfiltered_targets,
                 queue=queue)
 
-        nfiltered_targets = int(nfiltered_targets.get())
+        nfiltered_targets = int(nfiltered_targets.get().item())
 
         unfiltered_from_filtered_target_indices = \
                 unfiltered_from_filtered_target_indices[:nfiltered_targets]


### PR DESCRIPTION
Deprecated in numpy 1.25
https://numpy.org/doc/stable/release/1.25.0-notes.html#deprecations