### PR TITLE
minor fix + test (test_tree_of_boxes)

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -32786,6 +32786,22 @@
                 }
             },
             {
+                "code": "reportOperatorIssue",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportUnknownVariableType",
                 "range": {
                     "startColumn": 4,
@@ -32798,22 +32814,6 @@
                 "range": {
                     "startColumn": 32,
                     "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 70,
                     "lineCount": 1
                 }
             },
@@ -32906,6 +32906,70 @@
                 }
             },
             {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 17,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOperatorIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIndexIssue",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 18,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnnecessaryComparison",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIndexIssue",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 17,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 18,
@@ -32925,7 +32989,7 @@
                 "code": "reportUnnecessaryComparison",
                 "range": {
                     "startColumn": 27,
-                    "endColumn": 51,
+                    "endColumn": 79,
                     "lineCount": 1
                 }
             },
@@ -34800,6 +34864,30 @@
                 "range": {
                     "startColumn": 21,
                     "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnnecessaryComparison",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnnecessaryComparison",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnnecessaryComparison",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 28,
                     "lineCount": 1
                 }
             }

--- a/boxtree/tree_of_boxes.py
+++ b/boxtree/tree_of_boxes.py
@@ -174,10 +174,8 @@ def _apply_refine_flags_without_sorting(
             tob.nboxes
             + nchildren * np.arange(len(refine_parents)))
 
-    refine_parents_per_child = np.empty(
-            (nchildren, len(refine_parents)), dtype=np.intp)
-    refine_parents_per_child[:] = refine_parents.reshape(-1)
-    refine_parents_per_child = refine_parents_per_child.reshape(-1)
+    # Assign the parent box number for each new child box.
+    refine_parents_per_child = np.repeat(refine_parents, nchildren)
 
     box_parents = _resized_array(tob.box_parent_ids, nboxes_new)
     box_centers = _resized_array(tob.box_centers, nboxes_new)
@@ -230,19 +228,22 @@ def _apply_coarsen_flags(
         raise ValueError("attempting to coarsen non-leaf")
 
     coarsen_sources, = np.where(coarsen_flags)
+    if np.any(tob.box_parent_ids[coarsen_sources] < 0):
+        raise ValueError("cannot coarsen the root box")
     if coarsen_sources.size == 0:
         return tob
 
     coarsen_parents = tob.box_parent_ids[coarsen_sources]
-    coarsen_peers = tob.box_child_ids[:, coarsen_parents].reshape(-1)
+    coarsen_peers = tob.box_child_ids[:, coarsen_parents]
     coarsen_peer_is_leaf = box_is_leaf[coarsen_peers]
     coarsen_exec_flags = np.all(coarsen_peer_is_leaf, axis=0)
 
     # when a leaf box marked for coarsening has non-leaf peers
-    coarsen_flags_ignored = np.sum(coarsen_exec_flags != coarsen_flags)
-    if coarsen_flags_ignored:
-        msg = (f"{coarsen_flags_ignored} out of {np.sum(coarsen_flags)} coarsening "
-               "flags ignored to prevent removing non-leaf boxes")
+    coarsen_flags_ignored = ~coarsen_exec_flags
+    if np.any(coarsen_flags_ignored):
+        msg = (f"{np.sum(coarsen_flags_ignored)} out of "
+               f"{np.sum(coarsen_flags)} coarsening flags ignored "
+               "to prevent removing non-leaf boxes")
         if error_on_ignored_flags:
             raise RuntimeError(msg)
         else:
@@ -250,7 +251,7 @@ def _apply_coarsen_flags(
             warnings.warn(msg, stacklevel=3)
 
     # deleted boxes are marked as:
-    # level = inf
+    # level = sentinel (max int)
     # parent = -1
     coarsen_parents = coarsen_parents[coarsen_exec_flags]
     coarsen_peers = coarsen_peers[:, coarsen_exec_flags]
@@ -259,7 +260,7 @@ def _apply_coarsen_flags(
     box_children = tob.box_child_ids.copy()
     box_children[:, coarsen_parents] = 0
     box_levels = tob.box_levels.copy()
-    box_levels[coarsen_peers] = np.inf
+    box_levels[coarsen_peers] = np.iinfo(box_levels.dtype).max
 
     return TreeOfBoxes(
         box_centers=tob.box_centers,
@@ -285,12 +286,22 @@ def _sort_boxes_by_level(tob: TreeOfBoxes) -> TreeOfBoxes:
     if not np.any(np.diff(tob.box_levels) < 0):
         return tob
 
-    # reorder boxes to into non-decreasing levels
+    # reorder boxes into non-decreasing levels
     neworder = np.argsort(tob.box_levels)
+    old_to_new = np.empty_like(neworder)
+    old_to_new[neworder] = np.arange(len(neworder))
+
     box_centers = tob.box_centers[:, neworder]
+    box_levels = tob.box_levels[neworder]
     box_parent_ids = tob.box_parent_ids[neworder]
     box_child_ids = tob.box_child_ids[:, neworder]
-    box_levels = tob.box_levels[neworder]
+
+    # box_parent_ids and box_child_ids need to be updated to
+    # reflect the new box numbering
+    parent_has_id = box_parent_ids >= 0
+    box_parent_ids[parent_has_id] = old_to_new[box_parent_ids[parent_has_id]]
+    child_has_id = box_child_ids != 0
+    box_child_ids[child_has_id] = old_to_new[box_child_ids[child_has_id]]
 
     return TreeOfBoxes(
         box_centers=box_centers,
@@ -314,7 +325,7 @@ def _sort_boxes_by_level(tob: TreeOfBoxes) -> TreeOfBoxes:
 
 def _sort_and_prune_deleted_boxes(tob: TreeOfBoxes) -> TreeOfBoxes:
     tob = _sort_boxes_by_level(tob)
-    n_stale_boxes = np.sum(tob.box_levels == np.inf)
+    n_stale_boxes = np.sum(tob.box_levels == np.iinfo(tob.box_levels.dtype).max)
     newn = tob.nboxes - n_stale_boxes
 
     return TreeOfBoxes(

--- a/test/test_tree_of_boxes.py
+++ b/test/test_tree_of_boxes.py
@@ -40,8 +40,10 @@ from meshmode.array_context import (
 from pytools import obj_array
 
 from boxtree import (
+    coarsen_tree_of_boxes,
     make_meshmode_mesh_from_leaves,
     make_tree_of_boxes_root,
+    refine_tree_of_boxes,
     uniformly_refine_tree_of_boxes,
 )
 
@@ -257,6 +259,78 @@ def test_traversal_from_tob(actx_factory):
     from boxtree.traversal import FMMTraversalBuilder
     tg = FMMTraversalBuilder(actx)
     _trav, _ = tg(actx, tob)
+
+# }}}
+
+
+# {{{ test_refine_parent_child_consistency
+
+@pytest.mark.parametrize("dim", [1, 2, 3])
+def test_refine_parent_child_consistency(dim: int):
+    tob = make_tree_of_boxes_root((np.zeros(dim), np.ones(dim)))
+
+    tob = uniformly_refine_tree_of_boxes(tob)
+    tob = uniformly_refine_tree_of_boxes(tob)
+
+    nboxes = tob.nboxes
+    for box_id in range(nboxes):
+        for child_id in tob.box_child_ids[:, box_id]:
+            if child_id == 0:
+                continue
+            assert 0 < child_id < nboxes
+            assert tob.box_parent_ids[child_id] == box_id
+            assert tob.box_levels[child_id] == tob.box_levels[box_id] + 1
+
+# }}}
+
+
+# {{{ test_coarsen_tree_of_boxes
+
+@pytest.mark.parametrize("dim", [1, 2, 3])
+def test_coarsen_tree_of_boxes(dim: int):
+    tob = make_tree_of_boxes_root((np.zeros(dim), np.ones(dim)))
+    tob = uniformly_refine_tree_of_boxes(tob)
+
+    coarsen_flags = np.zeros(tob.nboxes, dtype=bool)
+    coarsen_flags[1:] = True
+    tob = coarsen_tree_of_boxes(tob, coarsen_flags)
+
+    assert tob.nboxes == 1
+    assert tob.box_parent_ids[0] == -1
+    assert tob.box_levels[0] == 0
+    assert np.all(tob.box_child_ids[:, 0] == 0)
+
+# }}}
+
+
+# {{{ test_out_of_order_refine
+
+@pytest.mark.parametrize("dim", [1, 2, 3])
+def test_out_of_order_refine(dim: int):
+    tob = make_tree_of_boxes_root((np.zeros(dim), np.ones(dim)))
+    tob = uniformly_refine_tree_of_boxes(tob)
+
+    flags = np.zeros(tob.nboxes, dtype=bool)
+    flags[1] = True
+    tob = refine_tree_of_boxes(tob, flags)
+
+    deep = np.where(tob.box_levels == 2)[0][0]
+    flags = np.zeros(tob.nboxes, dtype=bool)
+    flags[deep] = True
+    tob = refine_tree_of_boxes(tob, flags)
+
+    flags = np.zeros(tob.nboxes, dtype=bool)
+    flags[2] = True
+    tob = refine_tree_of_boxes(tob, flags)
+
+    nboxes = tob.nboxes
+    for box_id in range(nboxes):
+        for child_id in tob.box_child_ids[:, box_id]:
+            if child_id == 0:
+                continue
+            assert 0 < child_id < nboxes
+            assert tob.box_parent_ids[child_id] == box_id
+            assert tob.box_levels[child_id] == tob.box_levels[box_id] + 1
 
 # }}}
 

--- a/test/test_tree_of_boxes.py
+++ b/test/test_tree_of_boxes.py
@@ -29,7 +29,11 @@ import sys
 import numpy as np
 import pytest
 
-from arraycontext import pytest_generate_tests_for_array_contexts
+from arraycontext import (
+    ArrayContext,
+    ArrayContextFactory,
+    pytest_generate_tests_for_array_contexts,
+)
 
 # This means boxtree's tests have a hard dependency on meshmode. That's OK.
 from meshmode import _acf  # noqa: F401
@@ -40,6 +44,7 @@ from meshmode.array_context import (
 from pytools import obj_array
 
 from boxtree import (
+    TreeOfBoxes,
     coarsen_tree_of_boxes,
     make_meshmode_mesh_from_leaves,
     make_tree_of_boxes_root,
@@ -73,7 +78,7 @@ pytest_generate_tests = pytest_generate_tests_for_array_contexts([
 
 # {{{ make_global_leaf_quadrature
 
-def make_global_leaf_quadrature(actx, tob, order):
+def make_global_leaf_quadrature(actx: ArrayContext, tob: TreeOfBoxes, order: int):
     from meshmode.discretization.poly_element import (
         GaussLegendreTensorProductGroupFactory,
     )
@@ -145,7 +150,11 @@ def test_uniform_tree_of_boxes(actx_factory, dim, order, nlevels):
 
 @pytest.mark.parametrize("dim", [1, 2, 3])
 @pytest.mark.parametrize("order", [1, 2, 3])
-def test_uniform_tree_of_boxes_convergence(actx_factory, dim, order):
+def test_uniform_tree_of_boxes_convergence(
+            actx_factory: ArrayContextFactory,
+            dim: int,
+            order: int
+        ):
     actx = actx_factory()
 
     radius = np.pi
@@ -228,7 +237,7 @@ def test_tree_plot():
 # {{{ test_traversal_from_tob
 
 
-def test_traversal_from_tob(actx_factory):
+def test_traversal_from_tob(actx_factory: ArrayContextFactory):
     actx = actx_factory()
 
     radius = np.pi


### PR DESCRIPTION
### Fixes

  - (`_apply_refine_flags_without_sorting`): refining multiple boxes in one call gave the new children wrong parent IDs. `refine_parents_per_child` was built `(nchildren, len(refine_parents))` and flattened row-major (`np.tile`). But  `box_children[:, refine_parents]` numbers the new boxes in one contiguous block per parent. Now uses `np.repeat(refine_parents, nchildren)`.

  - (`_sort_boxes_by_level`): reordered the box arrays by `neworder` but didn't update the IDs stored in `box_parent_ids` and `box_child_ids`, which still referred to the old numbering. Sorting needs two steps - rearrange the boxes into their new positions, and remap the stored IDs to the new numbering.

  - (`_apply_coarsen_flags`, `_sort_and_prune_deleted_boxes`):
    - `box_levels` is an integer array, so using `np.inf` raises `OverflowError`.
    - `coarsen_peers` had a stray `.reshape(-1)` that flattened the `(2**dim, n_sources)`, so coarsen_exec_flags = np.all(coarsen_peer_is_leaf, axis=0) collapsed to a single scalar.
    - `coarsen_exec_flags != coarsen_flags` was wrong since they have different sizes.


Tests are included for the above fixes.
   